### PR TITLE
Task L solution contains incorrect visudo command

### DIFF
--- a/practice-questions/tasks/l/solution.md
+++ b/practice-questions/tasks/l/solution.md
@@ -10,7 +10,7 @@ sudo passwd sysadmin # science
 ```
 sudo usermod -aG sudo sysadmin
 sudo visudo
->> sysadmin ALL=(ALL) NOPASSWD: ALL
+>> sysadmin ALL = NOPASSWD: ALL
 ```
 
 4. The default shell for this user is ​zsh:

--- a/practice-questions/tasks/l/solution.md
+++ b/practice-questions/tasks/l/solution.md
@@ -10,7 +10,7 @@ sudo passwd sysadmin # science
 ```
 sudo usermod -aG sudo sysadmin
 sudo visudo
->> %sysadmin ALL= NOPASSWD: ALL
+>> sysadmin ALL=(ALL) NOPASSWD: ALL
 ```
 
 4. The default shell for this user is ​zsh:


### PR DESCRIPTION
Really appreciate this guide! I'm studying through the exam questions for my upcoming exam. 

While doing task L this morning, discovered that my Ubuntu machine didn't like the visudo command given here. A little research taught me that sysadmin is a user, not a group, so it doesn't need the %. There was also a missing (ALL) chunk that other definitions in the sudoers file had.

If there's something I didn't know, please correct me! I'm still learning. But I wanted to give back to this guide since it's so helpful, so I made a quick correction here for an easy update.